### PR TITLE
remove most references to `gt` -> `fp`

### DIFF
--- a/apps/cli/src/actions/checkout_branch.ts
+++ b/apps/cli/src/actions/checkout_branch.ts
@@ -41,7 +41,7 @@ function printBranchInfo(branchName: string, context: TContext) {
     context.splog.info(
       `This branch has fallen behind ${chalk.blueBright(
         context.engine.getParentPrecondition(branchName)
-      )} - you may want to ${chalk.cyan(`gt upstack restack`)}.`
+      )} - you may want to ${chalk.cyan(`fp upstack restack`)}.`
     );
   } else {
     const nearestAncestorNeedingRestack = context.engine
@@ -55,7 +55,7 @@ function printBranchInfo(branchName: string, context: TContext) {
           nearestAncestorNeedingRestack
         )} has fallen behind ${chalk.blueBright(
           context.engine.getParentPrecondition(nearestAncestorNeedingRestack)
-        )} - you may want to ${chalk.cyan(`gt stack restack`)}.`
+        )} - you may want to ${chalk.cyan(`fp stack restack`)}.`
       );
     }
   }

--- a/apps/cli/src/actions/create_branch.ts
+++ b/apps/cli/src/actions/create_branch.ts
@@ -61,7 +61,7 @@ export async function createBranchAction(
     context.splog.tip(
       [
         'To insert a created branch into the middle of your stack, use the `--insert` flag.',
-        "If you meant to insert this branch, you can rearrange your stack's dependencies with `gt upstack onto`",
+        "If you meant to insert this branch, you can rearrange your stack's dependencies with `fp upstack onto`",
       ].join('\n')
     );
     return;

--- a/apps/cli/src/actions/init.ts
+++ b/apps/cli/src/actions/init.ts
@@ -97,8 +97,8 @@ async function branchOnboardingFlow(context: TContext) {
   context.splog.tip(
     [
       "If you have an existing branch or stack that you'd like to start working on with Graphite, you can begin tracking it now!",
-      'To add other non-Graphite branches to Graphite later, check out `gt branch track`.',
-      'If you only want to use Graphite for new branches, feel free to exit now and use `gt branch create`.',
+      'To add other non-Graphite branches to Graphite later, check out `fp branch track`.',
+      'If you only want to use Graphite for new branches, feel free to exit now and use `fp branch create`.',
     ].join('\n')
   );
   if (

--- a/apps/cli/src/actions/print_conflict_status.ts
+++ b/apps/cli/src/actions/print_conflict_status.ts
@@ -33,14 +33,14 @@ export function printConflictStatus(
   );
   context.splog.info(`(1) resolve the listed merge conflicts`);
   context.splog.info(
-    `(2) mark them as resolved with ${chalk.cyan(`gt add .`)}`
+    `(2) mark them as resolved with ${chalk.cyan(`fp add .`)}`
   );
   context.splog.info(
     `(3) run ${chalk.cyan(
-      `gt continue`
+      `fp continue`
     )} to continue executing your previous Graphite command`
   );
   context.splog.info(
-    "It's safe to cancel the ongoing rebase with `gt rebase --abort`."
+    "It's safe to cancel the ongoing rebase with `fp rebase --abort`."
   );
 }

--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -74,7 +74,7 @@ export async function submitAction(
 
   context.splog.info(
     chalk.blueBright(
-      `🥞 Validating that this Graphite stack is ready to submit...`
+      `🥞 Validating that this Freephite stack is ready to submit...`
     )
   );
   context.splog.newline();
@@ -127,7 +127,7 @@ export async function submitAction(
             `Force-with-lease push of ${chalk.yellow(
               submissionInfo.head
             )} failed due to external changes to the remote branch.`,
-            'If you are collaborating on this stack, try `gt downstack get` to pull in changes.',
+            'If you are collaborating on this stack, try `fp downstack get` to pull in changes.',
             'Alternatively, use the `--force` option of this command to bypass the stale info warning.',
           ].join('\n')
         );

--- a/apps/cli/src/actions/submit/validate_branches.ts
+++ b/apps/cli/src/actions/submit/validate_branches.ts
@@ -39,7 +39,7 @@ async function validateNoMergedOrClosedBranches(
 
   const hasMultipleBranches = mergedOrClosedBranches.length > 1;
   context.splog.tip(
-    'You can use `gt repo sync` to find and delete all merged/closed branches automatically and rebase their children.'
+    'You can use `fp repo sync` to find and delete all merged/closed branches automatically and rebase their children.'
   );
 
   context.splog.warn(
@@ -106,7 +106,7 @@ function validateBaseRevisions(branchNames: string[], context: TContext): void {
             `You are trying to submit at least one branch that has not been restacked on its parent.`,
             `To resolve this, check out ${chalk.yellow(
               branchName
-            )} and run ${chalk.cyan(`gt upstack restack`)}.`,
+            )} and run ${chalk.cyan(`fp upstack restack`)}.`,
           ].join('\n')
         );
       }
@@ -116,7 +116,7 @@ function validateBaseRevisions(branchNames: string[], context: TContext): void {
           [
             `You are trying to submit at least one branch whose base does not match its parent remotely, without including its parent.`,
             `You may want to use ${chalk.cyan(
-              `gt stack submit`
+              `fp stack submit`
             )} to ensure that the ancestors of ${chalk.yellow(
               branchName
             )} are included in your submission.`,

--- a/apps/cli/src/commands/branch-commands/restack.ts
+++ b/apps/cli/src/commands/branch-commands/restack.ts
@@ -17,8 +17,8 @@ export const handler = async (argv: argsT): Promise<void> =>
       [
         `You are restacking a specific branch.`,
         `In common cases, we recommend you use:`,
-        `▸ gt stack restack`,
-        `▸ gt upstack restack`,
+        `▸ fp stack restack`,
+        `▸ fp upstack restack`,
         `because these will ensure any upstack branches will be restacked on their restacked parents.`,
         `If this branch has any descendants, they will likely need a restack after this command.`,
       ].join('\n')

--- a/apps/cli/src/commands/branch-commands/submit.ts
+++ b/apps/cli/src/commands/branch-commands/submit.ts
@@ -14,8 +14,8 @@ export const handler = async (argv: argsT): Promise<void> => {
       [
         `You are submitting a pull request for a specific branch.`,
         `In common cases, we recommend you use:`,
-        `▸ gt stack submit`,
-        `▸ gt downstack submit`,
+        `▸ fp stack submit`,
+        `▸ fp downstack submit`,
         `because these will ensure any downstack changes will be synced to existing PRs.`,
         `This submit will fail if the branch's remote parent doesn't match its local base.`,
       ].join('\n')

--- a/apps/cli/src/commands/branch.ts
+++ b/apps/cli/src/commands/branch.ts
@@ -2,7 +2,7 @@ import { Argv } from 'yargs';
 
 export const command = 'branch <command>';
 export const desc =
-  'Commands that operate on your current branch. Run `gt branch --help` to learn more.';
+  'Commands that operate on your current branch. Run `fp branch --help` to learn more.';
 
 export const aliases = ['b'];
 export const builder = function (yargs: Argv): Argv {

--- a/apps/cli/src/commands/commit.ts
+++ b/apps/cli/src/commands/commit.ts
@@ -2,7 +2,7 @@ import { Argv } from 'yargs';
 
 export const command = 'commit <command>';
 export const desc =
-  'Commands that operate on commits. Run `gt commit --help` to learn more.';
+  'Commands that operate on commits. Run `fp commit --help` to learn more.';
 
 export const aliases = ['c'];
 export const builder = function (yargs: Argv): Argv {

--- a/apps/cli/src/commands/downstack-commands/restack.ts
+++ b/apps/cli/src/commands/downstack-commands/restack.ts
@@ -18,8 +18,8 @@ export const handler = async (argv: argsT): Promise<void> =>
       [
         `You are restacking with downstack scope.`,
         `In common cases, we recommend you use:`,
-        `▸ gt stack restack`,
-        `▸ gt upstack restack`,
+        `▸ fp stack restack`,
+        `▸ fp upstack restack`,
         `because these will ensure any upstack branches will be restacked on their restacked parents.`,
         `If the current branch has any descendants, they will likely need a restack after this command.`,
       ].join('\n')

--- a/apps/cli/src/commands/downstack.ts
+++ b/apps/cli/src/commands/downstack.ts
@@ -2,7 +2,7 @@ import yargs from 'yargs';
 
 export const command = 'downstack <command>';
 export const desc =
-  'Commands that operate on a branch and its ancestors. Run `gt downstack --help` to learn more.';
+  'Commands that operate on a branch and its ancestors. Run `fp downstack --help` to learn more.';
 export const aliases = ['ds'];
 export const builder = function (yargs: yargs.Argv): yargs.Argv {
   return yargs

--- a/apps/cli/src/commands/feedback-commands/debug_context.ts
+++ b/apps/cli/src/commands/feedback-commands/debug_context.ts
@@ -10,14 +10,14 @@ const args = {
     optional: true,
     alias: 'r',
     describe:
-      'Accepts a json block created by `gt feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON.',
+      'Accepts a json block created by `fp feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON.',
   },
   'recreate-from-file': {
     type: 'string',
     optional: true,
     alias: 'f',
     describe:
-      'Accepts a file containing a json block created by `gt feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON.',
+      'Accepts a file containing a json block created by `fp feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON.',
   },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;

--- a/apps/cli/src/commands/feedback-commands/default.ts
+++ b/apps/cli/src/commands/feedback-commands/default.ts
@@ -19,7 +19,7 @@ const args = {
     type: 'boolean',
     default: false,
     describe:
-      "Include a blob of json describing your repo's state to help with debugging. Run 'gt feedback debug-context' to see what would be included.",
+      "Include a blob of json describing your repo's state to help with debugging. Run 'fp feedback debug-context' to see what would be included.",
   },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;

--- a/apps/cli/src/commands/feedback.ts
+++ b/apps/cli/src/commands/feedback.ts
@@ -8,5 +8,5 @@ export const builder = function (yargs: yargs.Argv): yargs.Argv {
       extensions: ['js'],
     })
     .strict()
-    .showHelpOnFail(false, `Use 'gt feedback --help' for usage`);
+    .showHelpOnFail(false, `Use 'fp feedback --help' for usage`);
 };

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -3,7 +3,7 @@ import { Argv } from 'yargs';
 export const aliases = ['r'];
 export const command = 'repo <command>';
 export const desc =
-  "Read or write Graphite's configuration settings for the current repo. Run `gt repo --help` to learn more.";
+  "Read or write Graphite's configuration settings for the current repo. Run `fp repo --help` to learn more.";
 
 export const builder = function (yargs: Argv): Argv {
   return yargs

--- a/apps/cli/src/commands/stack.ts
+++ b/apps/cli/src/commands/stack.ts
@@ -2,7 +2,7 @@ import yargs from 'yargs';
 
 export const command = 'stack <command>';
 export const desc =
-  'Commands that operate on your current stack of branches. Run `gt stack --help` to learn more.';
+  'Commands that operate on your current stack of branches. Run `fp stack --help` to learn more.';
 export const aliases = ['s'];
 export const builder = function (yargs: yargs.Argv): yargs.Argv {
   return yargs

--- a/apps/cli/src/commands/upstack-commands/submit.ts
+++ b/apps/cli/src/commands/upstack-commands/submit.ts
@@ -14,8 +14,8 @@ export const handler = async (argv: argsT): Promise<void> => {
       [
         `You are submitting with upstack scope.`,
         `In common cases, we recommend you use:`,
-        `▸ gt stack submit`,
-        `▸ gt downstack submit`,
+        `▸ fp stack submit`,
+        `▸ fp downstack submit`,
         `because these will ensure any downstack changes will be synced to existing PRs.`,
         `This submit will fail if the current branch's remote parent doesn't match its local base.`,
       ].join('\n')

--- a/apps/cli/src/commands/upstack.ts
+++ b/apps/cli/src/commands/upstack.ts
@@ -2,7 +2,7 @@ import yargs from 'yargs';
 
 export const command = 'upstack <command>';
 export const desc =
-  'Commands that operate on a branch and its descendants. Run `gt upstack --help` to learn more.';
+  'Commands that operate on a branch and its descendants. Run `fp upstack --help` to learn more.';
 export const aliases = ['us'];
 export const builder = function (yargs: yargs.Argv): yargs.Argv {
   return yargs

--- a/apps/cli/src/commands/user-commands/branch_prefix.ts
+++ b/apps/cli/src/commands/user-commands/branch_prefix.ts
@@ -41,7 +41,7 @@ export const handler = async (argv: argsT): Promise<void> => {
     } else {
       context.splog.info(
         context.userConfig.data.branchPrefix ||
-          'branch-prefix is not set. Try running `gt user branch-prefix --set <prefix>` to update the value.'
+          'branch-prefix is not set. Try running `fp user branch-prefix --set <prefix>` to update the value.'
       );
     }
   });

--- a/apps/cli/src/commands/user.ts
+++ b/apps/cli/src/commands/user.ts
@@ -2,7 +2,7 @@ import { Argv } from 'yargs';
 
 export const command = 'user <command>';
 export const desc =
-  "Read or write Graphite's user configuration settings. Run `gt user --help` to learn more.";
+  "Read or write Graphite's user configuration settings. Run `fp user --help` to learn more.";
 
 export const builder = function (yargs: Argv): Argv {
   return yargs

--- a/apps/cli/src/lib/errors.ts
+++ b/apps/cli/src/lib/errors.ts
@@ -58,7 +58,7 @@ export class UntrackedBranchError extends Error {
           branchName
         )}.`,
         `You can track it by specifying its parent with ${chalk.cyan(
-          `gt branch track`
+          `fp branch track`
         )}.`,
       ].join('\n')
     );
@@ -86,7 +86,7 @@ export class BlockedDuringRebaseError extends Error {
       [
         `This operation is blocked during a rebase.`,
         `You may still use git directly, and continue with ${chalk.cyan(
-          'gt continue'
+          'fp continue'
         )}.`,
       ].join('\n')
     );

--- a/apps/cli/src/lib/pre-yargs/deprecated_commands.ts
+++ b/apps/cli/src/lib/pre-yargs/deprecated_commands.ts
@@ -7,17 +7,17 @@ const NAV_WARNING = [
 
 const INFO_WARNING = [
   'The `branch` command `show` has been renamed.',
-  'Please use `info` (aka `gt bi`).',
+  'Please use `info` (aka `fp bi`).',
 ].join('\n');
 
 const GET_WARNING = [
   'The `downstack` command `sync` has been renamed.',
-  'Please use `get` (aka `gt dsg`).',
+  'Please use `get` (aka `fp dsg`).',
 ].join('\n');
 
 const FIX_WARNING = [
   'The `upstack` and `stack` command `fix` has been renamed.',
-  'Please use `restack` (aka `gt sr`/`gt usr`).',
+  'Please use `restack` (aka `fp sr`/`fp usr`).',
   'The `fix`/`f` alias will be removed in an upcoming version.',
 ].join('\n');
 

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -151,7 +151,7 @@ async function graphiteHelper(
       context.engine.rebaseInProgress()
     ) {
       throw new DetachedError(
-        `Did you mean to run ${chalk.cyan(`gt continue`)}?`
+        `Did you mean to run ${chalk.cyan(`fp continue`)}?`
       );
     }
     throw err;

--- a/apps/cli/src/lib/spiffy/repo_config_spf.ts
+++ b/apps/cli/src/lib/spiffy/repo_config_spf.ts
@@ -49,7 +49,7 @@ export const repoConfigFactory = spiffy({
         }
 
         throw new ExitFailedError(
-          "Could not determine the host of this repo (e.g. 'github.com' in the repo 'https://github.com/withgraphite/graphite-cli'). Please run `gt repo owner --set <owner>` to manually set the repo owner."
+          "Could not determine the host of this repo (e.g. 'github.com' in the repo 'https://github.com/withgraphite/graphite-cli'). Please run `fp repo owner --set <owner>` to manually set the repo owner."
         );
       },
 
@@ -65,7 +65,7 @@ export const repoConfigFactory = spiffy({
         }
 
         throw new ExitFailedError(
-          "Could not determine the owner of this repo (e.g. 'withgraphite' in the repo 'withgraphite/graphite-cli'). Please run `gt repo owner --set <owner>` to manually set the repo owner."
+          "Could not determine the owner of this repo (e.g. 'withgraphite' in the repo 'withgraphite/graphite-cli'). Please run `fp repo owner --set <owner>` to manually set the repo owner."
         );
       },
 
@@ -80,7 +80,7 @@ export const repoConfigFactory = spiffy({
         }
 
         throw new ExitFailedError(
-          "Could not determine the name of this repo (e.g. 'graphite-cli' in the repo 'withgraphite/graphite-cli'). Please run `gt repo name --set <owner>` to manually set the repo name."
+          "Could not determine the name of this repo (e.g. 'graphite-cli' in the repo 'withgraphite/graphite-cli'). Please run `fp repo name --set <owner>` to manually set the repo name."
         );
       },
     } as const;
@@ -102,7 +102,7 @@ function inferRepoGitHubInfo(remote: string): {
   });
 
   const inferError = new ExitFailedError(
-    `Failed to infer the owner and name of this repo from remote ${remote} "${url}". Please run \`gt repo owner --set <owner>\` and \`gt repo name --set <name>\` to manually set the repo owner/name. (e.g. in the repo 'withgraphite/graphite-cli', 'withgraphite' is the repo owner and 'graphite-cli' is the repo name)`
+    `Failed to infer the owner and name of this repo from remote ${remote} "${url}". Please run \`fp repo owner --set <owner>\` and \`fp repo name --set <name>\` to manually set the repo owner/name. (e.g. in the repo 'withgraphite/graphite-cli', 'withgraphite' is the repo owner and 'graphite-cli' is the repo name)`
   );
   if (!url) {
     throw inferError;

--- a/apps/cli/src/lib/utils/splog.ts
+++ b/apps/cli/src/lib/utils/splog.ts
@@ -41,7 +41,7 @@ export function composeSplog(
               [
                 '',
                 `${chalk.bold('tip')}: ${s}`,
-                chalk.italic('Feeling expert? `gt user tips --disable`'),
+                chalk.italic('Feeling expert? `fp user tips --disable`'),
                 '',
               ].join('\n')
             )


### PR DESCRIPTION
**Context:**
A lot of the logs still mention `Graphite` or `gt xxx` when referencing commands

**Changes In This Pull Request:**
Replace some of the wording to `Freephite` and `fp xxx`. I proabably missed some 

**Test Plan:**
🚢 
