### PR TITLE
Support `fp bs` without a PR in parent branch

### DIFF
--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -168,7 +168,6 @@ export async function submitAction(
   const comment = StackCommentBody.generate(context, prs);
   const owner = context.repoConfig.getRepoOwner();
   const repo = context.repoConfig.getRepoName();
-  // 1
 
   for (const pr of prs) {
     const existing = await octokit.request(

--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -168,6 +168,7 @@ export async function submitAction(
   const comment = StackCommentBody.generate(context, prs);
   const owner = context.repoConfig.getRepoOwner();
   const repo = context.repoConfig.getRepoName();
+  // 1
 
   for (const pr of prs) {
     const existing = await octokit.request(


### PR DESCRIPTION
**Context:**

Closes #11. 

Now you can submit a PR from a branch where the parent branch does not have a PR, or the PR is not known to freephite, and comments will still (somewhat) work. Probably more to fix here...

**Changes In This Pull Request:**

**Test Plan:**
