### PR TITLE
Implement a "fp repo trunk" command to quickly access the trunk branch

### DIFF
--- a/apps/cli/src/commands/repo-commands/repo_trunk.ts
+++ b/apps/cli/src/commands/repo-commands/repo_trunk.ts
@@ -1,0 +1,30 @@
+import yargs from 'yargs';
+import { graphite } from '../../lib/runner';
+import { checkoutBranch } from '../../actions/checkout_branch';
+
+const args = {} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = 'trunk';
+export const canonical = 'repo trunk';
+export const description = 'Switch the to repo trunk branch.';
+export const aliases = ['t'];
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+  return graphite(argv, canonical, async (context) => {
+    const trunk = context.repoConfig.getTrunk();
+
+    if (!trunk) {
+      context.splog.error('No trunk has been set yet, please set one first.');
+      return;
+    }
+
+    return checkoutBranch(
+      {
+        branchName: trunk,
+      },
+      context
+    );
+  });
+};

--- a/apps/cli/src/lib/spiffy/repo_config_spf.ts
+++ b/apps/cli/src/lib/spiffy/repo_config_spf.ts
@@ -35,6 +35,8 @@ export const repoConfigFactory = spiffy({
         update((data) => (data.trunk = trunk));
       },
 
+      getTrunk: () => data.trunk,
+
       graphiteInitialized: (): boolean => !!data.trunk,
 
       getRepoHost: (): string => {


### PR DESCRIPTION
**Context:**

The current API was lacking a command to quickly access the trunk branch from wherever you are like on the latest version of `Graphite`.

**Changes In This Pull Request:**
This PR add a new repo command `repo_trunk` that is calling a `checkoutBranch` on the trunk if this one is set (which should be the case as it's defined during the `init`).

**Test Plan:**

- Build the cli files
- Run it locally

Commands to run:
- `fp repo trunk` (or `fp rt`)
