### PR TITLE
Add existing PR when sync pr info

### DIFF
--- a/src/actions/sync_pr_info.ts
+++ b/src/actions/sync_pr_info.ts
@@ -6,7 +6,7 @@ export async function syncPrInfo(
   branchNames: string[],
   context: TContext
 ): Promise<TPRInfoToUpsert> {
-  const authToken = context.userConfig.getAuthToken();
+  const authToken = context.userConfig.getFPAuthToken();
   if (authToken === undefined) {
     return [];
   }


### PR DESCRIPTION
**Context:**

I'm sharing a stack of branches with a coworker. This would allow us to not recreate PRs on `fp stack submit` but retrieve the existing one.

It's the first time I'm writing typescript code. This is probably not following all best practices, happy to take feedback.

Related  issue https://github.com/bradymadden97/freephite/issues/23

**Changes In This Pull Request:**

1. Use auth-fp token when syncing PR. This means that `getPrInfoForBranches` was probably not reached out before.

2. Query Github API to find PR number for branches without PR.

**Test Plan:**

On a new branch untracked by freephite
* push the branch
* manually create the PR
* `fp branch track`
* `fp repo sync`

With the `fp` 0.1.6,
* the branch metadata do not contains the PR (visible with `git cat-file -p $(cat .git/refs/branch-metadata/add-already-existing-prs)`). 
* `fp stack submit` will create a new PR.

With this PR, the PR is in added to the branch metadata and `fp stack submit` does not try to create it.

EDIT does not work with PR made on fork.

Related  issue https://github.com/bradymadden97/freephite/issues/23

